### PR TITLE
v0.25.17: Fix pipe animation to show continuous flow instead of pulses

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -1,3 +1,3 @@
-export const CARD_VERSION = '0.25.16';
+export const CARD_VERSION = '0.25.17';
 export const CARD_NAME = 'heat-pump-flow-card';
 export const BUILD_TIMESTAMP = new Date().toISOString();

--- a/src/heat-pump-flow-card.ts
+++ b/src/heat-pump-flow-card.ts
@@ -893,8 +893,8 @@ export class HeatPumpFlowCard extends LitElement {
                   <stop offset="80%" stop-color="rgba(230, 90, 60, 0.5)" />
                   <stop offset="90%" stop-color="rgba(200, 60, 40, 0)" />
                   <stop offset="100%" stop-color="rgba(200, 60, 40, 0)" />
-                  <animate attributeName="x1" values="0%;100%" dur="${flowAnimSpeed}s" begin="0s" repeatCount="indefinite" />
-                  <animate attributeName="x2" values="100%;200%" dur="${flowAnimSpeed}s" begin="0s" repeatCount="indefinite" />
+                  <animate attributeName="x1" values="0%;50%" dur="${flowAnimSpeed}s" begin="0s" repeatCount="indefinite" />
+                  <animate attributeName="x2" values="100%;150%" dur="${flowAnimSpeed}s" begin="0s" repeatCount="indefinite" />
                 </linearGradient>
               </defs>
               <path class="flow-gradient"
@@ -920,8 +920,8 @@ export class HeatPumpFlowCard extends LitElement {
                   <stop offset="80%" stop-color="rgba(230, 90, 60, 0.5)" />
                   <stop offset="90%" stop-color="rgba(200, 60, 40, 0)" />
                   <stop offset="100%" stop-color="rgba(200, 60, 40, 0)" />
-                  <animate attributeName="x1" values="0%;100%" dur="${flowAnimSpeed}s" begin="0.3s" repeatCount="indefinite" />
-                  <animate attributeName="x2" values="100%;200%" dur="${flowAnimSpeed}s" begin="0.3s" repeatCount="indefinite" />
+                  <animate attributeName="x1" values="0%;50%" dur="${flowAnimSpeed}s" begin="0.3s" repeatCount="indefinite" />
+                  <animate attributeName="x2" values="100%;150%" dur="${flowAnimSpeed}s" begin="0.3s" repeatCount="indefinite" />
                 </linearGradient>
               </defs>
               <path class="flow-gradient"
@@ -947,8 +947,8 @@ export class HeatPumpFlowCard extends LitElement {
                   <stop offset="80%" stop-color="rgba(230, 90, 60, 0.5)" />
                   <stop offset="90%" stop-color="rgba(200, 60, 40, 0)" />
                   <stop offset="100%" stop-color="rgba(200, 60, 40, 0)" />
-                  <animate attributeName="x1" values="0%;100%" dur="${flowAnimSpeed}s" begin="0.6s" repeatCount="indefinite" />
-                  <animate attributeName="x2" values="100%;200%" dur="${flowAnimSpeed}s" begin="0.6s" repeatCount="indefinite" />
+                  <animate attributeName="x1" values="0%;50%" dur="${flowAnimSpeed}s" begin="0.6s" repeatCount="indefinite" />
+                  <animate attributeName="x2" values="100%;150%" dur="${flowAnimSpeed}s" begin="0.6s" repeatCount="indefinite" />
                 </linearGradient>
               </defs>
               <path class="flow-gradient"
@@ -974,8 +974,8 @@ export class HeatPumpFlowCard extends LitElement {
                   <stop offset="80%" stop-color="rgba(230, 90, 60, 0.5)" />
                   <stop offset="90%" stop-color="rgba(200, 60, 40, 0)" />
                   <stop offset="100%" stop-color="rgba(200, 60, 40, 0)" />
-                  <animate attributeName="x1" values="0%;100%" dur="${flowAnimSpeed}s" begin="0.9s" repeatCount="indefinite" />
-                  <animate attributeName="x2" values="100%;200%" dur="${flowAnimSpeed}s" begin="0.9s" repeatCount="indefinite" />
+                  <animate attributeName="x1" values="0%;50%" dur="${flowAnimSpeed}s" begin="0.9s" repeatCount="indefinite" />
+                  <animate attributeName="x2" values="100%;150%" dur="${flowAnimSpeed}s" begin="0.9s" repeatCount="indefinite" />
                 </linearGradient>
               </defs>
               <path class="flow-gradient"
@@ -1001,8 +1001,8 @@ export class HeatPumpFlowCard extends LitElement {
                   <stop offset="80%" stop-color="rgba(80, 135, 220, 0.5)" />
                   <stop offset="90%" stop-color="rgba(50, 100, 180, 0)" />
                   <stop offset="100%" stop-color="rgba(50, 100, 180, 0)" />
-                  <animate attributeName="x1" values="100%;0%" dur="${flowAnimSpeed}s" begin="1.2s" repeatCount="indefinite" />
-                  <animate attributeName="x2" values="200%;100%" dur="${flowAnimSpeed}s" begin="1.2s" repeatCount="indefinite" />
+                  <animate attributeName="x1" values="100%;50%" dur="${flowAnimSpeed}s" begin="1.2s" repeatCount="indefinite" />
+                  <animate attributeName="x2" values="150%;100%" dur="${flowAnimSpeed}s" begin="1.2s" repeatCount="indefinite" />
                 </linearGradient>
               </defs>
               <path class="flow-gradient"
@@ -1028,8 +1028,8 @@ export class HeatPumpFlowCard extends LitElement {
                   <stop offset="80%" stop-color="rgba(80, 135, 220, 0.5)" />
                   <stop offset="90%" stop-color="rgba(50, 100, 180, 0)" />
                   <stop offset="100%" stop-color="rgba(50, 100, 180, 0)" />
-                  <animate attributeName="x1" values="100%;0%" dur="${flowAnimSpeed}s" begin="1.5s" repeatCount="indefinite" />
-                  <animate attributeName="x2" values="200%;100%" dur="${flowAnimSpeed}s" begin="1.5s" repeatCount="indefinite" />
+                  <animate attributeName="x1" values="100%;50%" dur="${flowAnimSpeed}s" begin="1.5s" repeatCount="indefinite" />
+                  <animate attributeName="x2" values="150%;100%" dur="${flowAnimSpeed}s" begin="1.5s" repeatCount="indefinite" />
                 </linearGradient>
               </defs>
               <path class="flow-gradient"
@@ -1055,10 +1055,10 @@ export class HeatPumpFlowCard extends LitElement {
                   <stop offset="80%" stop-color="rgba(230, 90, 60, 0.5)" />
                   <stop offset="90%" stop-color="rgba(200, 60, 40, 0)" />
                   <stop offset="100%" stop-color="rgba(200, 60, 40, 0)" />
-                  <animate attributeName="x1" values="0%;30%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
-                  <animate attributeName="y1" values="0%;100%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
-                  <animate attributeName="x2" values="30%;60%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
-                  <animate attributeName="y2" values="100%;200%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
+                  <animate attributeName="x1" values="0%;15%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
+                  <animate attributeName="y1" values="0%;50%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
+                  <animate attributeName="x2" values="30%;45%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
+                  <animate attributeName="y2" values="100%;150%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
                 </linearGradient>
               </defs>
               <path class="flow-gradient"
@@ -1084,8 +1084,8 @@ export class HeatPumpFlowCard extends LitElement {
                   <stop offset="80%" stop-color="rgba(230, 90, 60, 0.5)" />
                   <stop offset="90%" stop-color="rgba(200, 60, 40, 0)" />
                   <stop offset="100%" stop-color="rgba(200, 60, 40, 0)" />
-                  <animate attributeName="y1" values="0%;100%" dur="${flowAnimSpeed}s" begin="0.7s" repeatCount="indefinite" />
-                  <animate attributeName="y2" values="100%;200%" dur="${flowAnimSpeed}s" begin="0.7s" repeatCount="indefinite" />
+                  <animate attributeName="y1" values="0%;50%" dur="${flowAnimSpeed}s" begin="0.7s" repeatCount="indefinite" />
+                  <animate attributeName="y2" values="100%;150%" dur="${flowAnimSpeed}s" begin="0.7s" repeatCount="indefinite" />
                 </linearGradient>
               </defs>
               <path class="flow-gradient"
@@ -1111,10 +1111,10 @@ export class HeatPumpFlowCard extends LitElement {
                   <stop offset="80%" stop-color="rgba(80, 135, 220, 0.5)" />
                   <stop offset="90%" stop-color="rgba(50, 100, 180, 0)" />
                   <stop offset="100%" stop-color="rgba(50, 100, 180, 0)" />
-                  <animate attributeName="x1" values="100%;0%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
-                  <animate attributeName="y1" values="100%;0%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
-                  <animate attributeName="x2" values="0%;-100%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
-                  <animate attributeName="y2" values="0%;-100%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
+                  <animate attributeName="x1" values="100%;50%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
+                  <animate attributeName="y1" values="100%;50%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
+                  <animate attributeName="x2" values="0%;-50%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
+                  <animate attributeName="y2" values="0%;-50%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
                 </linearGradient>
               </defs>
               <path class="flow-gradient"


### PR DESCRIPTION
Changed all 9 flow gradient animations from 100% movement to 50% movement. The gradient pattern has two bright spots spaced 50% apart. By moving the gradient only 50% per loop, when the animation repeats, the next bright spot enters immediately as the previous one exits, creating seamless continuous flow instead of visible gaps/pulses.

Fixes:
- flow-grad-1 to 4: Horizontal supply pipes (0%→50%, 100%→150%)
- flow-grad-5 to 6: Horizontal return pipes (100%→50%, 150%→100%)
- flow-grad-7: Diagonal G2 to DHW (x: 0%→15%, y: 0%→50%)
- flow-grad-8: Vertical DHW coil (y: 0%→50%, 100%→150%)
- flow-grad-9: Diagonal DHW return (x: 100%→50%, y: 100%→50%)