### PR TITLE
Exclude flow-gradient animations from path drop-shadow filter

### DIFF
--- a/dist/heat-pump-flow-card.js
+++ b/dist/heat-pump-flow-card.js
@@ -192,8 +192,8 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
     filter: none; /* Will be set by animation */
   }
 
-  /* Pipe styling */
-  path {
+  /* Pipe styling - exclude flow-gradient animations from drop-shadow */
+  path:not(.flow-gradient) {
     filter: drop-shadow(0 2px 4px rgba(0,0,0,0.2));
   }
 

--- a/heat-pump-flow-card.js
+++ b/heat-pump-flow-card.js
@@ -192,8 +192,8 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
     filter: none; /* Will be set by animation */
   }
 
-  /* Pipe styling */
-  path {
+  /* Pipe styling - exclude flow-gradient animations from drop-shadow */
+  path:not(.flow-gradient) {
     filter: drop-shadow(0 2px 4px rgba(0,0,0,0.2));
   }
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -194,8 +194,8 @@ export const cardStyles = css`
     filter: none; /* Will be set by animation */
   }
 
-  /* Pipe styling */
-  path {
+  /* Pipe styling - exclude flow-gradient animations from drop-shadow */
+  path:not(.flow-gradient) {
     filter: drop-shadow(0 2px 4px rgba(0,0,0,0.2));
   }
 


### PR DESCRIPTION
The CSS rule applying drop-shadow to all path elements was affecting the flow-gradient animation paths, making them appear gray and muted instead of showing their vibrant colors.

Changed the path filter selector from:
  path { filter: drop-shadow(...); }
to:
  path:not(.flow-gradient) { filter: drop-shadow(...); }

This ensures that:
- Static pipe paths still get the drop-shadow for depth
- Animated flow-gradient paths render with clean, vibrant colors without the dark shadow overlay that was making them look gray

Fixes the issue where DHW mode flow animations (and all flow animations) appeared washed out and gray instead of showing their proper red/orange or blue colors.