### PR TITLE
Fix DHW pipe animation direction to vertical for vertical pipes

### DIFF
--- a/dist/heat-pump-flow-card.js
+++ b/dist/heat-pump-flow-card.js
@@ -454,16 +454,16 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
                   stroke-linecap="butt"
                   opacity="${i.flowRate>this.config.animation.idle_threshold?"1":"0"}"></path>
 
-            <!-- G2 to DHW (horizontal hot) - DHW mode only -->
+            <!-- G2 to DHW (vertical hot) - DHW mode only -->
             <defs>
-              <linearGradient id="flow-grad-7" x1="0%" y1="0%" x2="100%" y2="0%">
+              <linearGradient id="flow-grad-7" x1="0%" y1="0%" x2="0%" y2="100%">
                 <stop offset="0%" stop-color="rgba(200, 60, 40, 0.3)" />
                 <stop offset="40%" stop-color="rgba(240, 100, 70, 0.6)" />
                 <stop offset="50%" stop-color="rgba(255, 130, 90, 0.9)" />
                 <stop offset="60%" stop-color="rgba(240, 100, 70, 0.6)" />
                 <stop offset="100%" stop-color="rgba(200, 60, 40, 0.3)" />
-                <animate attributeName="x1" values="-50%;50%" dur="${Y}s" begin="0.4s" repeatCount="indefinite" />
-                <animate attributeName="x2" values="50%;150%" dur="${Y}s" begin="0.4s" repeatCount="indefinite" />
+                <animate attributeName="y1" values="-50%;50%" dur="${Y}s" begin="0.4s" repeatCount="indefinite" />
+                <animate attributeName="y2" values="50%;150%" dur="${Y}s" begin="0.4s" repeatCount="indefinite" />
               </linearGradient>
             </defs>
             <path class="flow-gradient"
@@ -494,16 +494,16 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
                   stroke-linecap="butt"
                   opacity="${a.isActive&&t.flowRate>this.config.animation.idle_threshold?"1":"0"}"></path>
 
-            <!-- DHW to HP return (predominantly horizontal cold) - DHW mode only -->
+            <!-- DHW to HP return (vertical cold) - DHW mode only -->
             <defs>
-              <linearGradient id="flow-grad-9" x1="0%" y1="0%" x2="100%" y2="0%">
+              <linearGradient id="flow-grad-9" x1="0%" y1="0%" x2="0%" y2="100%">
                 <stop offset="0%" stop-color="rgba(50, 100, 180, 0.3)" />
                 <stop offset="40%" stop-color="rgba(80, 140, 220, 0.6)" />
                 <stop offset="50%" stop-color="rgba(110, 170, 255, 0.9)" />
                 <stop offset="60%" stop-color="rgba(80, 140, 220, 0.6)" />
                 <stop offset="100%" stop-color="rgba(50, 100, 180, 0.3)" />
-                <animate attributeName="x1" values="50%;-50%" dur="${Y}s" begin="1.0s" repeatCount="indefinite" />
-                <animate attributeName="x2" values="150%;50%" dur="${Y}s" begin="1.0s" repeatCount="indefinite" />
+                <animate attributeName="y1" values="50%;-50%" dur="${Y}s" begin="1.0s" repeatCount="indefinite" />
+                <animate attributeName="y2" values="150%;50%" dur="${Y}s" begin="1.0s" repeatCount="indefinite" />
               </linearGradient>
             </defs>
             <path class="flow-gradient"

--- a/heat-pump-flow-card.js
+++ b/heat-pump-flow-card.js
@@ -454,16 +454,16 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
                   stroke-linecap="butt"
                   opacity="${i.flowRate>this.config.animation.idle_threshold?"1":"0"}"></path>
 
-            <!-- G2 to DHW (horizontal hot) - DHW mode only -->
+            <!-- G2 to DHW (vertical hot) - DHW mode only -->
             <defs>
-              <linearGradient id="flow-grad-7" x1="0%" y1="0%" x2="100%" y2="0%">
+              <linearGradient id="flow-grad-7" x1="0%" y1="0%" x2="0%" y2="100%">
                 <stop offset="0%" stop-color="rgba(200, 60, 40, 0.3)" />
                 <stop offset="40%" stop-color="rgba(240, 100, 70, 0.6)" />
                 <stop offset="50%" stop-color="rgba(255, 130, 90, 0.9)" />
                 <stop offset="60%" stop-color="rgba(240, 100, 70, 0.6)" />
                 <stop offset="100%" stop-color="rgba(200, 60, 40, 0.3)" />
-                <animate attributeName="x1" values="-50%;50%" dur="${Y}s" begin="0.4s" repeatCount="indefinite" />
-                <animate attributeName="x2" values="50%;150%" dur="${Y}s" begin="0.4s" repeatCount="indefinite" />
+                <animate attributeName="y1" values="-50%;50%" dur="${Y}s" begin="0.4s" repeatCount="indefinite" />
+                <animate attributeName="y2" values="50%;150%" dur="${Y}s" begin="0.4s" repeatCount="indefinite" />
               </linearGradient>
             </defs>
             <path class="flow-gradient"
@@ -494,16 +494,16 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
                   stroke-linecap="butt"
                   opacity="${a.isActive&&t.flowRate>this.config.animation.idle_threshold?"1":"0"}"></path>
 
-            <!-- DHW to HP return (predominantly horizontal cold) - DHW mode only -->
+            <!-- DHW to HP return (vertical cold) - DHW mode only -->
             <defs>
-              <linearGradient id="flow-grad-9" x1="0%" y1="0%" x2="100%" y2="0%">
+              <linearGradient id="flow-grad-9" x1="0%" y1="0%" x2="0%" y2="100%">
                 <stop offset="0%" stop-color="rgba(50, 100, 180, 0.3)" />
                 <stop offset="40%" stop-color="rgba(80, 140, 220, 0.6)" />
                 <stop offset="50%" stop-color="rgba(110, 170, 255, 0.9)" />
                 <stop offset="60%" stop-color="rgba(80, 140, 220, 0.6)" />
                 <stop offset="100%" stop-color="rgba(50, 100, 180, 0.3)" />
-                <animate attributeName="x1" values="50%;-50%" dur="${Y}s" begin="1.0s" repeatCount="indefinite" />
-                <animate attributeName="x2" values="150%;50%" dur="${Y}s" begin="1.0s" repeatCount="indefinite" />
+                <animate attributeName="y1" values="50%;-50%" dur="${Y}s" begin="1.0s" repeatCount="indefinite" />
+                <animate attributeName="y2" values="150%;50%" dur="${Y}s" begin="1.0s" repeatCount="indefinite" />
               </linearGradient>
             </defs>
             <path class="flow-gradient"

--- a/src/heat-pump-flow-card.ts
+++ b/src/heat-pump-flow-card.ts
@@ -878,16 +878,16 @@ export class HeatPumpFlowCard extends LitElement {
                   stroke-linecap="butt"
                   opacity="${hvacState.flowRate > this.config.animation!.idle_threshold ? '1' : '0'}"></path>
 
-            <!-- G2 to DHW (horizontal hot) - DHW mode only -->
+            <!-- G2 to DHW (vertical hot) - DHW mode only -->
             <defs>
-              <linearGradient id="flow-grad-7" x1="0%" y1="0%" x2="100%" y2="0%">
+              <linearGradient id="flow-grad-7" x1="0%" y1="0%" x2="0%" y2="100%">
                 <stop offset="0%" stop-color="rgba(200, 60, 40, 0.3)" />
                 <stop offset="40%" stop-color="rgba(240, 100, 70, 0.6)" />
                 <stop offset="50%" stop-color="rgba(255, 130, 90, 0.9)" />
                 <stop offset="60%" stop-color="rgba(240, 100, 70, 0.6)" />
                 <stop offset="100%" stop-color="rgba(200, 60, 40, 0.3)" />
-                <animate attributeName="x1" values="-50%;50%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
-                <animate attributeName="x2" values="50%;150%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
+                <animate attributeName="y1" values="-50%;50%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
+                <animate attributeName="y2" values="50%;150%" dur="${flowAnimSpeed}s" begin="0.4s" repeatCount="indefinite" />
               </linearGradient>
             </defs>
             <path class="flow-gradient"
@@ -918,16 +918,16 @@ export class HeatPumpFlowCard extends LitElement {
                   stroke-linecap="butt"
                   opacity="${g2ValveState.isActive && hpState.flowRate > this.config.animation!.idle_threshold ? '1' : '0'}"></path>
 
-            <!-- DHW to HP return (predominantly horizontal cold) - DHW mode only -->
+            <!-- DHW to HP return (vertical cold) - DHW mode only -->
             <defs>
-              <linearGradient id="flow-grad-9" x1="0%" y1="0%" x2="100%" y2="0%">
+              <linearGradient id="flow-grad-9" x1="0%" y1="0%" x2="0%" y2="100%">
                 <stop offset="0%" stop-color="rgba(50, 100, 180, 0.3)" />
                 <stop offset="40%" stop-color="rgba(80, 140, 220, 0.6)" />
                 <stop offset="50%" stop-color="rgba(110, 170, 255, 0.9)" />
                 <stop offset="60%" stop-color="rgba(80, 140, 220, 0.6)" />
                 <stop offset="100%" stop-color="rgba(50, 100, 180, 0.3)" />
-                <animate attributeName="x1" values="50%;-50%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
-                <animate attributeName="x2" values="150%;50%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
+                <animate attributeName="y1" values="50%;-50%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
+                <animate attributeName="y2" values="150%;50%" dur="${flowAnimSpeed}s" begin="1.0s" repeatCount="indefinite" />
               </linearGradient>
             </defs>
             <path class="flow-gradient"


### PR DESCRIPTION
- Revert G2-to-DHW gradient from horizontal to vertical (y-axis animation)
- Revert DHW-to-HP gradient from horizontal to vertical (y-axis animation)
- Vertical pipes need vertical gradients to flow properly along pipe direction
- Horizontal gradients on vertical pipes create static gray band effect