### PR TITLE
Fix DHW tank percentage display positioning

### DIFF
--- a/dist/heat-pump-flow-card.js
+++ b/dist/heat-pump-flow-card.js
@@ -941,11 +941,11 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
 
               <!-- Tank status display (always shown) -->
               ${o.tankTemp?G`
-                <text x="45" y="185" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
+                <text x="45" y="165" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
                   ${x}% | ${this.formatValue(o.tankTemp,1)}°${this.config.temperature?.unit||"C"}
                 </text>
               `:G`
-                <text x="45" y="185" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
+                <text x="45" y="165" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
                   ${x}%
                 </text>
               `}

--- a/heat-pump-flow-card.js
+++ b/heat-pump-flow-card.js
@@ -941,11 +941,11 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
 
               <!-- Tank status display (always shown) -->
               ${o.tankTemp?G`
-                <text x="45" y="185" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
+                <text x="45" y="165" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
                   ${x}% | ${this.formatValue(o.tankTemp,1)}°${this.config.temperature?.unit||"C"}
                 </text>
               `:G`
-                <text x="45" y="185" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
+                <text x="45" y="165" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
                   ${x}%
                 </text>
               `}

--- a/src/heat-pump-flow-card.ts
+++ b/src/heat-pump-flow-card.ts
@@ -1370,11 +1370,11 @@ export class HeatPumpFlowCard extends LitElement {
 
               <!-- Tank status display (always shown) -->
               ${dhwState.tankTemp ? html`
-                <text x="45" y="185" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
+                <text x="45" y="165" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
                   ${dhwFillPercentage}% | ${this.formatValue(dhwState.tankTemp, 1)}°${this.config.temperature?.unit || 'C'}
                 </text>
               ` : html`
-                <text x="45" y="185" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
+                <text x="45" y="165" text-anchor="middle" fill="#e74c3c" font-size="12" font-weight="bold">
                   ${dhwFillPercentage}%
                 </text>
               `}


### PR DESCRIPTION
The DHW tank percentage was displaying 20 pixels too low (y=185) compared to the buffer tank percentage (y=165). This fix aligns both tank percentage displays at the same vertical position relative to their tank bottom caps.