### PR TITLE
Fix DHW tank inlet layout: adjust water tower position and temperatur…

### DIFF
--- a/dist/heat-pump-flow-card.js
+++ b/dist/heat-pump-flow-card.js
@@ -354,14 +354,14 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
             <!-- DHW TANK INLET/OUTLET PIPES (street water in, hot water out) -->
             <!-- Pipe: Street water inlet to DHW tank (cold water supply to vertical center) -->
             <path id="dhw-tank-inlet-path"
-                  d="M 360 420 L 435 420"
+                  d="M 305 420 L 435 420"
                   stroke="${u}"
                   stroke-width="12"
                   fill="none"
                   stroke-linecap="butt"/>
 
-            <!-- Water source icon (e.g., water tower) at inlet start with gap -->
-            <image x="295" y="395" width="50" height="50"
+            <!-- Water source icon (e.g., water tower) at inlet start - rendered after pipe for z-order -->
+            <image x="250" y="395" width="50" height="50"
                    href="${this.config.dhw_tank?.tank_inlet_icon_url||"https://cdn-icons-png.flaticon.com/512/764/764408.png"}"
                    opacity="0.8"/>
 
@@ -1169,7 +1169,7 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
             ${this.renderTemperatureIndicator(385,470,this.config.temperature_status?.points?.dhw_outlet?.entity||this.config.dhw_tank?.outlet_temp_entity,o.outletTemp,this.config.temperature_status?.points?.dhw_outlet,f)}
 
             <!-- DHW Tank Street Water Inlet (cold water supply) -->
-            ${this.renderTemperatureIndicator(398,420,this.config.temperature_status?.points?.dhw_tank_inlet?.entity||this.config.dhw_tank?.tank_inlet_temp_entity,o.tankInletTemp??0,this.config.temperature_status?.points?.dhw_tank_inlet,u)}
+            ${this.renderTemperatureIndicator(370,420,this.config.temperature_status?.points?.dhw_tank_inlet?.entity||this.config.dhw_tank?.tank_inlet_temp_entity,o.tankInletTemp??0,this.config.temperature_status?.points?.dhw_tank_inlet,u)}
 
             <!-- DHW Tank Hot Water Outlet (to house) -->
             ${this.renderTemperatureIndicator(510,380,this.config.temperature_status?.points?.dhw_tank_outlet?.entity||this.config.dhw_tank?.tank_outlet_temp_entity,o.tankOutletTemp??0,this.config.temperature_status?.points?.dhw_tank_outlet,g)}

--- a/heat-pump-flow-card.js
+++ b/heat-pump-flow-card.js
@@ -354,14 +354,14 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
             <!-- DHW TANK INLET/OUTLET PIPES (street water in, hot water out) -->
             <!-- Pipe: Street water inlet to DHW tank (cold water supply to vertical center) -->
             <path id="dhw-tank-inlet-path"
-                  d="M 360 420 L 435 420"
+                  d="M 305 420 L 435 420"
                   stroke="${u}"
                   stroke-width="12"
                   fill="none"
                   stroke-linecap="butt"/>
 
-            <!-- Water source icon (e.g., water tower) at inlet start with gap -->
-            <image x="295" y="395" width="50" height="50"
+            <!-- Water source icon (e.g., water tower) at inlet start - rendered after pipe for z-order -->
+            <image x="250" y="395" width="50" height="50"
                    href="${this.config.dhw_tank?.tank_inlet_icon_url||"https://cdn-icons-png.flaticon.com/512/764/764408.png"}"
                    opacity="0.8"/>
 
@@ -1169,7 +1169,7 @@ var HeatPumpFlowCard=function(t){"use strict";function e(t,e,i,o){var a,r=argume
             ${this.renderTemperatureIndicator(385,470,this.config.temperature_status?.points?.dhw_outlet?.entity||this.config.dhw_tank?.outlet_temp_entity,o.outletTemp,this.config.temperature_status?.points?.dhw_outlet,f)}
 
             <!-- DHW Tank Street Water Inlet (cold water supply) -->
-            ${this.renderTemperatureIndicator(398,420,this.config.temperature_status?.points?.dhw_tank_inlet?.entity||this.config.dhw_tank?.tank_inlet_temp_entity,o.tankInletTemp??0,this.config.temperature_status?.points?.dhw_tank_inlet,u)}
+            ${this.renderTemperatureIndicator(370,420,this.config.temperature_status?.points?.dhw_tank_inlet?.entity||this.config.dhw_tank?.tank_inlet_temp_entity,o.tankInletTemp??0,this.config.temperature_status?.points?.dhw_tank_inlet,u)}
 
             <!-- DHW Tank Hot Water Outlet (to house) -->
             ${this.renderTemperatureIndicator(510,380,this.config.temperature_status?.points?.dhw_tank_outlet?.entity||this.config.dhw_tank?.tank_outlet_temp_entity,o.tankOutletTemp??0,this.config.temperature_status?.points?.dhw_tank_outlet,g)}

--- a/src/heat-pump-flow-card.ts
+++ b/src/heat-pump-flow-card.ts
@@ -869,14 +869,14 @@ export class HeatPumpFlowCard extends LitElement {
             <!-- DHW TANK INLET/OUTLET PIPES (street water in, hot water out) -->
             <!-- Pipe: Street water inlet to DHW tank (cold water supply to vertical center) -->
             <path id="dhw-tank-inlet-path"
-                  d="M 360 420 L 435 420"
+                  d="M 305 420 L 435 420"
                   stroke="${dhwTankInletColor}"
                   stroke-width="12"
                   fill="none"
                   stroke-linecap="butt"/>
 
-            <!-- Water source icon (e.g., water tower) at inlet start with gap -->
-            <image x="295" y="395" width="50" height="50"
+            <!-- Water source icon (e.g., water tower) at inlet start - rendered after pipe for z-order -->
+            <image x="250" y="395" width="50" height="50"
                    href="${this.config.dhw_tank?.tank_inlet_icon_url || 'https://cdn-icons-png.flaticon.com/512/764/764408.png'}"
                    opacity="0.8"/>
 
@@ -1741,7 +1741,7 @@ export class HeatPumpFlowCard extends LitElement {
 
             <!-- DHW Tank Street Water Inlet (cold water supply) -->
             ${this.renderTemperatureIndicator(
-              398,
+              370,
               420,
               this.config.temperature_status?.points?.dhw_tank_inlet?.entity || this.config.dhw_tank?.tank_inlet_temp_entity,
               dhwState.tankInletTemp ?? 0,


### PR DESCRIPTION
Changes Made
Moved water tower icon further left: Changed position from x=295 to x=250 (moved 45px left) to prevent conflicts with other elements

Extended inlet pipe: Updated pipe path from M 360 420 to M 305 420, extending it to connect properly with the water tower icon (which now ends at x=300)

Adjusted temperature indicator: Moved from x=398 to x=370 to prevent overlap with the tank edge (which starts at x=400). The indicator now sits nicely centered on the pipe between the water tower and tank.

Z-order optimization: The water tower icon was already rendered after the pipe in the SVG, which means it naturally appears in front of the pipe visually.

Visual Result
The water tower icon is now positioned at x=250, ending at x=300
The inlet pipe extends from x=305 (5px gap from tower) to x=435 (tank edge)
The temperature indicator sits at x=370, with its 12px radius giving 12px clearance on each side
The icon appears in front of the pipe for a clean visual connection